### PR TITLE
Fix packaged footer and macOS bundle lifecycle

### DIFF
--- a/bongo_cat.spec
+++ b/bongo_cat.spec
@@ -6,6 +6,25 @@ import sys
 from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 
 block_cipher = None
+APP_NAME = 'BongoCat'
+APP_ICON = 'img/cat-rest.png' if os.path.exists('img/cat-rest.png') else None
+IS_MACOS = sys.platform == 'darwin'
+
+
+def app_version():
+    """Return the release tag version when available, otherwise package version."""
+    ref_name = os.environ.get('GITHUB_REF_NAME', '')
+    if ref_name.startswith('v') and ref_name[1:]:
+        return ref_name[1:]
+
+    try:
+        from bongo_cat import __version__
+        return __version__
+    except Exception:
+        return '0.0.0'
+
+
+APP_VERSION = app_version()
 
 # Collect all data files
 datas = []
@@ -53,15 +72,15 @@ pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
 exe = EXE(
     pyz,
     a.scripts,
-    a.binaries,
-    a.zipfiles,
-    a.datas,
+    [] if IS_MACOS else a.binaries,
+    [] if IS_MACOS else a.zipfiles,
+    [] if IS_MACOS else a.datas,
     [],
-    name='BongoCat',
+    name=APP_NAME,
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,
-    upx=True,
+    upx=not IS_MACOS,
     upx_exclude=[],
     runtime_tmpdir=None,
     console=False,  # No console window
@@ -70,19 +89,34 @@ exe = EXE(
     target_arch=None,
     codesign_identity=None,
     entitlements_file=None,
-    icon='img/cat-rest.png' if os.path.exists('img/cat-rest.png') else None,
+    icon=APP_ICON,
+    exclude_binaries=IS_MACOS,
 )
 
 # macOS app bundle
-if sys.platform == 'darwin':
-    app = BUNDLE(
+if IS_MACOS:
+    coll = COLLECT(
         exe,
-        name='BongoCat.app',
-        icon='img/cat-rest.png' if os.path.exists('img/cat-rest.png') else None,
+        a.binaries,
+        a.zipfiles,
+        a.datas,
+        strip=False,
+        upx=False,
+        upx_exclude=[],
+        name=APP_NAME,
+    )
+
+    app = BUNDLE(
+        coll,
+        name=f'{APP_NAME}.app',
+        icon=APP_ICON,
         bundle_identifier='com.luinbytes.bongocat',
+        version=APP_VERSION,
         info_plist={
             'NSPrincipalClass': 'NSApplication',
             'NSHighResolutionCapable': 'True',
             'LSBackgroundOnly': 'False',
+            'CFBundleShortVersionString': APP_VERSION,
+            'CFBundleVersion': APP_VERSION,
         },
     )

--- a/bongo_cat/__init__.py
+++ b/bongo_cat/__init__.py
@@ -6,7 +6,7 @@ from .input import InputManager
 from .utils import resource_path, setup_logging
 from . import animations
 
-__version__ = "1.0.0"
+__version__ = "2.0.4"
 __author__ = "luinbytes"
 __description__ = "Interactive desktop pet that responds to keyboard, mouse, and controller inputs"
 

--- a/bongo_cat/ui/main_window.py
+++ b/bongo_cat/ui/main_window.py
@@ -985,19 +985,23 @@ class BongoCatWindow(QtWidgets.QWidget):
         except Exception:
             return False
 
+    def _ensure_footer_opacity_effect(self):
+        """Create the footer opacity effect only if Qt has deleted it."""
+        if self._footer_effect_alive():
+            return
+
+        self.footer_opacity_effect = QtWidgets.QGraphicsOpacityEffect(self.footer_widget)
+        self.footer_widget.setGraphicsEffect(self.footer_opacity_effect)
+        if hasattr(self, 'footer_animation'):
+            self.footer_animation.setTargetObject(self.footer_opacity_effect)
+            self.footer_animation.setPropertyName(b"opacity")
+
     def fade_footer(self, fade_in: bool):
         """Fade the footer in or out."""
         # If the footer should always be visible
         if not self.config.hidden_footer:
             self.footer_widget.show()
-
-            # Make sure the opacity effect is valid
-            if not self._footer_effect_alive():
-                self.footer_opacity_effect = QtWidgets.QGraphicsOpacityEffect(self.footer_widget)
-                self.footer_widget.setGraphicsEffect(self.footer_opacity_effect)
-                self.footer_animation.setTargetObject(self.footer_opacity_effect)
-                self.footer_animation.setPropertyName(b"opacity")
-
+            self._ensure_footer_opacity_effect()
             self.footer_opacity_effect.setOpacity(1.0)
             return
 
@@ -1005,12 +1009,7 @@ class BongoCatWindow(QtWidgets.QWidget):
         if fade_in and not self.is_hovering:
             return
 
-        # Create/validate the opacity effect
-        if not self._footer_effect_alive():
-            self.footer_opacity_effect = QtWidgets.QGraphicsOpacityEffect(self.footer_widget)
-            self.footer_widget.setGraphicsEffect(self.footer_opacity_effect)
-            self.footer_animation.setTargetObject(self.footer_opacity_effect)
-            self.footer_animation.setPropertyName(b"opacity")
+        self._ensure_footer_opacity_effect()
 
         # Set up and start the animation
         self.footer_animation.stop()
@@ -1338,25 +1337,23 @@ class BongoCatWindow(QtWidgets.QWidget):
         # Apply settings
         self.config.save()
         
-        # Stop callbacks before replacing the graphics effect in setup_footer_style().
+        # Stop footer callbacks while settings rewrite style and visibility.
         self.footer_animation.stop()
-        self.footer_opacity_effect = None
 
         # Update the footer styling with new alpha
         self.setup_footer_style()
-
-        # Recreate the opacity effect to ensure it's valid
-        self.footer_opacity_effect = QtWidgets.QGraphicsOpacityEffect(self.footer_widget)
-        self.footer_widget.setGraphicsEffect(self.footer_opacity_effect)
-
-        # Reconnect animation to the new effect
-        self.footer_animation.setTargetObject(self.footer_opacity_effect)
-        self.footer_animation.setPropertyName(b"opacity")
+        self._ensure_footer_opacity_effect()
         
         # Update footer visibility based on hidden_footer setting
         if not self.config.hidden_footer:
             self.footer_widget.show()
             self.footer_opacity_effect.setOpacity(1.0)
+        elif self.is_hovering:
+            self.footer_widget.show()
+            self.footer_opacity_effect.setOpacity(1.0)
+        else:
+            self.footer_opacity_effect.setOpacity(0.0)
+            self.footer_widget.hide()
         
         # Update UI based on new settings
         if self.config.always_show_points:

--- a/tests/test_footer_settings.py
+++ b/tests/test_footer_settings.py
@@ -33,6 +33,43 @@ class TestFooterSettings(unittest.TestCase):
 
         self.assertLess(call_lines["stop"], call_lines["style"])
 
+    def test_apply_settings_does_not_replace_live_footer_graphics_effect(self):
+        apply_settings = self._main_window_method("apply_settings")
+
+        creates_opacity_effect = [
+            node for node in ast.walk(apply_settings)
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "QGraphicsOpacityEffect"
+            )
+        ]
+        calls_set_graphics_effect = [
+            node for node in ast.walk(apply_settings)
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "setGraphicsEffect"
+            )
+        ]
+        clears_footer_effect = [
+            node for node in ast.walk(apply_settings)
+            if (
+                isinstance(node, ast.Assign)
+                and any(
+                    isinstance(target, ast.Attribute)
+                    and target.attr == "footer_opacity_effect"
+                    for target in node.targets
+                )
+                and isinstance(node.value, ast.Constant)
+                and node.value.value is None
+            )
+        ]
+
+        self.assertEqual([], creates_opacity_effect)
+        self.assertEqual([], calls_set_graphics_effect)
+        self.assertEqual([], clears_footer_effect)
+
     def test_footer_style_does_not_replace_footer_graphics_effect(self):
         setup_footer_style = self._main_window_method("setup_footer_style")
 

--- a/tests/test_packaging_spec.py
+++ b/tests/test_packaging_spec.py
@@ -1,0 +1,63 @@
+"""Tests for PyInstaller packaging configuration."""
+
+import ast
+from pathlib import Path
+import unittest
+
+
+class TestPackagingSpec(unittest.TestCase):
+    """Packaging should follow platform-specific PyInstaller patterns."""
+
+    def setUp(self):
+        source = Path("bongo_cat.spec").read_text(encoding="utf-8")
+        self.tree = ast.parse(source)
+
+    def _assigns_name_from_call(self, target_name, call_name):
+        return [
+            node for node in ast.walk(self.tree)
+            if (
+                isinstance(node, ast.Assign)
+                and any(
+                    isinstance(target, ast.Name) and target.id == target_name
+                    for target in node.targets
+                )
+                and isinstance(node.value, ast.Call)
+                and isinstance(node.value.func, ast.Name)
+                and node.value.func.id == call_name
+            )
+        ]
+
+    def test_macos_bundle_uses_collected_onedir_app(self):
+        """macOS .app bundles should wrap COLLECT output, not the one-file exe."""
+        collect_assignments = self._assigns_name_from_call("coll", "COLLECT")
+        bundle_assignments = self._assigns_name_from_call("app", "BUNDLE")
+
+        self.assertTrue(collect_assignments)
+        self.assertTrue(bundle_assignments)
+
+        bundle_call = bundle_assignments[0].value
+        self.assertIsInstance(bundle_call.args[0], ast.Name)
+        self.assertEqual("coll", bundle_call.args[0].id)
+
+    def test_macos_bundle_sets_version_metadata(self):
+        bundle_assignments = self._assigns_name_from_call("app", "BUNDLE")
+        self.assertTrue(bundle_assignments)
+
+        keywords = {keyword.arg: keyword.value for keyword in bundle_assignments[0].value.keywords}
+
+        self.assertIn("version", keywords)
+        self.assertIn("info_plist", keywords)
+
+        info_plist = keywords["info_plist"]
+        self.assertIsInstance(info_plist, ast.Dict)
+        plist_keys = {
+            key.value for key in info_plist.keys
+            if isinstance(key, ast.Constant)
+        }
+
+        self.assertIn("CFBundleShortVersionString", plist_keys)
+        self.assertIn("CFBundleVersion", plist_keys)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Keep the footer opacity effect alive across settings apply instead of deleting and recreating it during the Apply click path.
- Add regression coverage that `apply_settings()` no longer replaces the live footer graphics effect.
- Build macOS `.app` bundles with the documented PyInstaller onedir `EXE(exclude_binaries) -> COLLECT -> BUNDLE` layout and populate bundle version metadata from the release tag.

## Investigation notes
- Related to #6: the source path stopped crashing, but the packaged Windows executable still crashed on `settings -> always show total -> apply`. The remaining lifecycle difference was that `apply_settings()` still replaced the live `QGraphicsOpacityEffect` while the settings click/event flow was active.
- Related to #7: the macOS crash report showed an early abort in the small app binary and bundle version `0.0.0`. The current spec wrapped the `EXE` directly in `BUNDLE`; PyInstaller docs advise the onedir `COLLECT` bundle layout for macOS apps and against onefile `.app` bundles.

## Local verification
- `python -m pytest tests/test_footer_settings.py tests/test_packaging_spec.py -q` -> 7 passed
- `python -m pytest -q` -> 20 passed, 2 skipped
- `QT_QPA_PLATFORM=offscreen PYNPUT_BACKEND=dummy ../bongocat-build-venv/bin/python ...` settings-apply source smoke -> passed
- `../bongocat-build-venv/bin/pyinstaller --clean --noconfirm bongo_cat.spec` on Linux -> completed and produced `dist/BongoCat`

## Limitations
- I did not run the Windows `.exe` repro locally.
- I did not run the macOS DMG/app locally.
- This PR should be validated by the release workflow/package artifacts and, ideally, by a Windows and Apple Silicon smoke before claiming either issue is closed.
