### PR TITLE
Release packaged settings crash fix as v2.0.5

### DIFF
--- a/bongo_cat/__init__.py
+++ b/bongo_cat/__init__.py
@@ -6,7 +6,7 @@ from .input import InputManager
 from .utils import resource_path, setup_logging
 from . import animations
 
-__version__ = "2.0.4"
+__version__ = "2.0.5"
 __author__ = "luinbytes"
 __description__ = "Interactive desktop pet that responds to keyboard, mouse, and controller inputs"
 


### PR DESCRIPTION
## Summary
- release the already-merged packaged Qt footer lifecycle fix as v2.0.5
- keep the change limited to the runtime version bump

## Verification
- `python3 -m unittest discover tests -v` -> 22 passed, 2 expected skips
- `git diff --check` -> clean

Addresses #9 and #10. The issues stay open for reporter validation of the new Windows artifact.