### PR TITLE
fix(settings): load packaged skins and preserve config edits

### DIFF
--- a/.codex/skills/verify-bongocat/SKILL.md
+++ b/.codex/skills/verify-bongocat/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: verify-bongocat
+description: Drive Bongo Cat's PyQt settings window when a change needs real Apply-button, skin-discovery, rendered-state, or config-persistence proof.
+---
+
+# Verify Bongo Cat
+
+Use this skill for source-level checks of Bongo Cat's desktop UI. Read the [feature map](features/README.md) before choosing a recipe. A Windows PyInstaller build and a reporter retest remain separate acceptance checks.
+
+## Launch
+
+Run commands from the repository root. The helper resolves the repository from its own path and creates a short-lived offscreen Qt application.
+
+```bash
+python .codex/skills/verify-bongocat/scripts/control.py settings-apply \
+  --evidence-dir /tmp/verify-bongocat-settings
+```
+
+The helper exits after the drive. Exit code `0` means that the real Apply-button path and its persistence checks passed.
+
+## Doctor
+
+Run the read-only doctor before a drive or when Qt setup looks wrong.
+
+```bash
+python .codex/skills/verify-bongocat/scripts/control.py doctor
+```
+
+Require `status` to be `ok`, `skin_count` to be `3`, and `skin_ids` to contain `default`, `neon`, and `retro`. Doctor does not create a Bongo Cat config file.
+
+## Drive
+
+Use `settings-apply` for the settings and skin recipes. The helper changes to an unrelated temporary working directory before it imports the app. It sets an isolated `APPDATA`, uses the dummy `pynput` backend, and renders Qt offscreen.
+
+The drive opens the production settings window. It locates `skinDropdown`, `soundEnabledCheckbox`, and `applySettingsButton` by Qt `objectName`. It captures the panel, unchecks sounds, clicks the real Apply button with `QTest.mouseClick()`, captures the result, and reloads the saved config through a new `ConfigManager`.
+
+## Evidence
+
+Pass an absolute, task-owned evidence directory. The helper preserves these files:
+
+- `settings-before.png` shows the populated skin selector before the action.
+- `settings-after.png` shows the rendered unchecked sound setting after Apply.
+- `result.json` records the source revision, Python and Qt versions, resolved skin path, skin IDs, selected skin value and type, error-dialog count, persisted sound value, and cleanup result.
+- `bongo.ini` is a copy of the isolated saved config.
+
+Keep the evidence until the task handoff. A final screenshot without the action and persisted read-back is not proof.
+
+## Cleanup
+
+The helper hides and deletes only the Qt widgets it creates. It quits its own `QApplication` and removes its temporary working and `APPDATA` directories. It does not start `InputManager`, kill by process name, or touch an existing Bongo Cat session. Cleanup preserves the evidence directory.
+
+## Helpers
+
+`scripts/control.py` is the only helper. Run `python .codex/skills/verify-bongocat/scripts/control.py --help` for its commands. Do not import it into production code.

--- a/.codex/skills/verify-bongocat/features/README.md
+++ b/.codex/skills/verify-bongocat/features/README.md
@@ -1,0 +1,37 @@
+# Bongo Cat verification map
+
+This directory maps Bongo Cat's main user paths to repeatable checks. Read this index first, then open the feature file that matches the change.
+
+## Baseline preconditions
+
+- Install `requirements.txt` in the selected Python environment.
+- Change to the repository root.
+- Run `python .codex/skills/verify-bongocat/scripts/control.py doctor` and require all three bundled skins.
+- Use a new absolute evidence directory for each reviewed run.
+- Do not drive an existing Bongo Cat process.
+
+## Driving conventions
+
+- Run source checks with `QT_QPA_PLATFORM=offscreen` and `PYNPUT_BACKEND=dummy`. `control.py` sets both values before importing Bongo Cat.
+- Use Qt `objectName` values rather than coordinates or tab order.
+- Exercise the production widget and signal path.
+- Read persisted values with a new `ConfigManager`.
+- Keep evidence outside the helper's scratch directory.
+
+## Proof and skip reporting
+
+- Capture the rendered state before and after the user action.
+- Record the selected skin as both a value and a Python type.
+- Copy only the isolated config. Never copy a user's config into evidence.
+- Report source-level proof separately from a packaged Windows run and a reporter retest.
+- Name any mapped entry point that the current helper cannot drive.
+
+## Feature entry contract
+
+Each feature file has exactly four H2 sections. Follow the commands and observable results in order. Do not claim a different entry point as proof for a skipped path.
+
+## Features
+
+- [Settings](settings.md) covers opening the settings window, applying values, and reloading the saved config.
+- [Skins](skins.md) covers bundled discovery, selection, and unrelated-working-directory launches.
+- [Slap counter](slap-counter.md) covers visible count changes and preservation of completed direct INI edits.

--- a/.codex/skills/verify-bongocat/features/settings.md
+++ b/.codex/skills/verify-bongocat/features/settings.md
@@ -1,0 +1,31 @@
+# Settings
+
+Settings lets a user change Bongo Cat behavior and persist the selected values with **Apply**.
+
+## Sub-features
+
+- `settings-open` opens the separate settings window.
+- `settings-apply` saves the selected values without closing Bongo Cat.
+- `settings-restart` loads saved values in a fresh application state.
+
+## How to get to it (user POV)
+
+- Hover over Bongo Cat and choose the settings button in the footer.
+- Open Settings from the app's controls, change a value, and choose **Apply**.
+
+## Driving it with control.py
+
+Preconditions:
+
+- `python .codex/skills/verify-bongocat/scripts/control.py doctor` reports `status` as `ok`.
+- The evidence path is absolute and belongs to the current task.
+
+- **Open and capture.** Run `python .codex/skills/verify-bongocat/scripts/control.py settings-apply --evidence-dir <absolute-path>`. `settings-before.png` shows the settings window and a populated **Cat Skin** selector.
+- **Apply.** The helper unchecks **Enable Sounds** and clicks `applySettingsButton` with `QTest.mouseClick()`. `settings-after.png` shows the unchecked control.
+- **Confirm persistence.** Read `result.json`. `apply_error_count` is `0` and `persisted_sound_enabled` is `false`. The copied `bongo.ini` has `sound_enabled = false`.
+
+## Gotchas
+
+- A surviving Qt process is insufficient when Apply did not save the value.
+- Source-level offscreen proof does not replace a packaged Windows check.
+- The helper owns its isolated config. Do not point it at a user profile.

--- a/.codex/skills/verify-bongocat/features/skins.md
+++ b/.codex/skills/verify-bongocat/features/skins.md
@@ -1,0 +1,32 @@
+# Skins
+
+Skins lets a user choose one of the bundled cat appearances even when Bongo Cat starts outside the repository directory.
+
+## Sub-features
+
+- `skins-discover` finds `default`, `neon`, and `retro` from the application resource directory.
+- `skins-select` stores a string skin ID in the config.
+- `skins-custom` keeps an explicitly supplied skin directory authoritative.
+
+## How to get to it (user POV)
+
+- Open Settings and use the **Cat Skin** selector.
+- Restart Bongo Cat after adding a custom skin directory under the application `skins` directory.
+
+## Driving it with control.py
+
+Preconditions:
+
+- The repository contains the three bundled skin directories and their image files.
+- `python .codex/skills/verify-bongocat/scripts/control.py doctor` reports `skin_count` as `3` from an unrelated working directory.
+
+- **Inspect discovery.** Run `python .codex/skills/verify-bongocat/scripts/control.py doctor`. Require `skin_ids` to contain `default`, `neon`, and `retro`.
+- **Capture selection.** Run `python .codex/skills/verify-bongocat/scripts/control.py settings-apply --evidence-dir <absolute-path>`. `settings-before.png` shows a non-empty selector.
+- **Confirm the boundary.** Read `result.json`. `selected_skin_type` is `str`, `selected_skin_id` is `default`, and `resolved_skins_dir` is an absolute application resource path.
+- **Check custom injection.** Run `python -m unittest tests.test_skin_manager.TestSkinManagerPaths.test_explicit_relative_skin_directory_stays_authoritative -v`. The supplied relative path remains unchanged.
+
+## Gotchas
+
+- The process working directory is not the application resource directory.
+- A fallback cat image can render while the skin selector is empty. Inspect the selector and the recorded IDs.
+- Custom skin injection is a source API check. The control helper uses bundled skins.

--- a/.codex/skills/verify-bongocat/features/slap-counter.md
+++ b/.codex/skills/verify-bongocat/features/slap-counter.md
@@ -1,0 +1,30 @@
+# Slap counter
+
+The slap counter increments for global input and saves the count without replacing completed direct INI edits.
+
+## Sub-features
+
+- `slap-visible` updates the count shown by Bongo Cat.
+- `slap-persist` restores the saved count after restart.
+- `slap-preserve-settings` changes only `slaps` in the latest valid INI file.
+
+## How to get to it (user POV)
+
+- Press a key, click a mouse button, or use a controller while Bongo Cat is running.
+- Open the INI file from the footer, finish an edit, and restart Bongo Cat to load it.
+
+## Driving it with control.py
+
+Preconditions:
+
+- `python .codex/skills/verify-bongocat/scripts/control.py doctor` reports `status` as `ok`.
+- No existing Bongo Cat session uses the isolated test config.
+
+- **Check the persistence rule.** Run `python -m unittest tests.test_config.TestConfigFileOperations.test_slap_count_update_preserves_completed_external_edit -v`. The test completes an external edit before the production slap-count writer runs and reads the result through a restarted `ConfigManager`.
+- **Record the control limit.** `control.py` does not synthesize global operating-system input. Report the visible counter path as unverified until a human presses a key in an owned test instance and sees the count increase by one.
+
+## Gotchas
+
+- `control.py` does not start global input listeners because they could capture the operator's real keyboard and mouse.
+- Direct INI changes load after restart. Bongo Cat does not hot-reload them.
+- Finish the editor write before the next slap. An external editor does not share a lock with Bongo Cat.

--- a/.codex/skills/verify-bongocat/scripts/control.py
+++ b/.codex/skills/verify-bongocat/scripts/control.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+
+import argparse
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Dict, Iterator, List, Optional, Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+@dataclass(frozen=True)
+class VerificationRun:
+    repo_root: Path
+    working_dir: Path
+    appdata_dir: Path
+    evidence_dir: Path
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    status: str
+    revision: str
+    python_version: str
+    qt_version: str
+    working_directory: str
+    resolved_skins_dir: str
+    skin_ids: List[str]
+    selected_skin_id: Optional[str]
+    selected_skin_type: str
+    apply_error_count: int
+    persisted_sound_enabled: bool
+    evidence_files: List[str]
+    scratch_removed: bool
+
+
+@contextmanager
+def isolated_environment(run: VerificationRun) -> Iterator[None]:
+    previous_cwd = Path.cwd()
+    previous_values: Dict[str, Optional[str]] = {
+        name: os.environ.get(name)
+        for name in (
+            "APPDATA",
+            "PYNPUT_BACKEND",
+            "PYGAME_HIDE_SUPPORT_PROMPT",
+            "QT_QPA_PLATFORM",
+        )
+    }
+    os.environ.update(
+        APPDATA=str(run.appdata_dir),
+        PYNPUT_BACKEND="dummy",
+        PYGAME_HIDE_SUPPORT_PROMPT="1",
+        QT_QPA_PLATFORM="offscreen",
+    )
+    os.chdir(str(run.working_dir))
+    sys.path.insert(0, str(run.repo_root))
+    try:
+        yield
+    finally:
+        os.chdir(str(previous_cwd))
+        if sys.path and sys.path[0] == str(run.repo_root):
+            sys.path.pop(0)
+        for name, value in previous_values.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
+def revision(repo_root: Path) -> str:
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD"],
+        cwd=str(repo_root),
+        text=True,
+    ).strip()
+
+
+def doctor(repo_root: Path) -> int:
+    with tempfile.TemporaryDirectory(prefix="verify-bongocat-doctor-") as scratch:
+        scratch_path = Path(scratch)
+        run = VerificationRun(
+            repo_root=repo_root,
+            working_dir=scratch_path / "working",
+            appdata_dir=scratch_path / "appdata",
+            evidence_dir=scratch_path / "unused-evidence",
+        )
+        run.working_dir.mkdir()
+        run.appdata_dir.mkdir()
+        with isolated_environment(run):
+            from PyQt5 import QtCore, QtWidgets
+            from bongo_cat.models.skin_manager import SkinManager
+
+            app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+            manager = SkinManager()
+            skin_ids = sorted(manager.get_skin_ids())
+            payload = {
+                "status": "ok" if skin_ids == ["default", "neon", "retro"] else "error",
+                "python_version": sys.version.split()[0],
+                "qt_version": QtCore.QT_VERSION_STR,
+                "resolved_skins_dir": manager.skins_dir,
+                "skin_count": len(skin_ids),
+                "skin_ids": skin_ids,
+            }
+            app.quit()
+
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0 if payload["status"] == "ok" else 1
+
+
+def drive_settings_apply(run: VerificationRun) -> VerificationResult:
+    run.evidence_dir.mkdir(parents=True, exist_ok=True)
+    before_path = run.evidence_dir / "settings-before.png"
+    after_path = run.evidence_dir / "settings-after.png"
+    config_copy_path = run.evidence_dir / "bongo.ini"
+    result_path = run.evidence_dir / "result.json"
+    window = None
+    app = None
+    result_values = None
+
+    with isolated_environment(run):
+        from PyQt5 import QtCore, QtTest, QtWidgets
+        from bongo_cat.models.config import ConfigManager
+        from bongo_cat.ui.main_window import BongoCatWindow
+
+        app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+        try:
+            window = BongoCatWindow()
+            window.show()
+            window.open_settings_dialog()
+            app.processEvents()
+
+            settings_panel = window.findChild(QtWidgets.QWidget, "settingsPanel")
+            skin_dropdown = window.findChild(QtWidgets.QComboBox, "skinDropdown")
+            sound_checkbox = window.findChild(
+                QtWidgets.QCheckBox,
+                "soundEnabledCheckbox",
+            )
+            apply_button = window.findChild(
+                QtWidgets.QPushButton,
+                "applySettingsButton",
+            )
+            if None in (settings_panel, skin_dropdown, sound_checkbox, apply_button):
+                raise RuntimeError("The settings UI is missing a verification handle")
+            if not settings_panel.grab().save(str(before_path), "PNG"):
+                raise RuntimeError(f"Could not save {before_path}")
+
+            selected_skin = skin_dropdown.currentData()
+            apply_errors = []
+            original_critical = QtWidgets.QMessageBox.critical
+            QtWidgets.QMessageBox.critical = lambda *_args: apply_errors.append(
+                "apply-error"
+            )
+            try:
+                sound_checkbox.setChecked(False)
+                QtTest.QTest.mouseClick(apply_button, QtCore.Qt.LeftButton)
+                app.processEvents()
+            finally:
+                QtWidgets.QMessageBox.critical = original_critical
+
+            if not settings_panel.grab().save(str(after_path), "PNG"):
+                raise RuntimeError(f"Could not save {after_path}")
+
+            persisted = ConfigManager(window.config.config_path)
+            shutil.copy2(window.config.config_path, config_copy_path)
+            skin_ids = sorted(window.skin_manager.get_skin_ids())
+            failures = []
+            if skin_ids != ["default", "neon", "retro"]:
+                failures.append("bundled skin discovery did not return three skins")
+            if not isinstance(selected_skin, str):
+                failures.append("the selected skin ID is not a string")
+            if apply_errors:
+                failures.append("Apply requested an error dialog")
+            if persisted.sound_enabled:
+                failures.append("sound_enabled did not persist as false")
+
+            result_values = {
+                "status": "ok" if not failures else "error",
+                "revision": revision(run.repo_root),
+                "python_version": sys.version.split()[0],
+                "qt_version": QtCore.QT_VERSION_STR,
+                "working_directory": str(run.working_dir),
+                "resolved_skins_dir": str(window.skin_manager.skins_dir),
+                "skin_ids": skin_ids,
+                "selected_skin_id": selected_skin if isinstance(selected_skin, str) else None,
+                "selected_skin_type": type(selected_skin).__name__,
+                "apply_error_count": len(apply_errors),
+                "persisted_sound_enabled": persisted.sound_enabled,
+                "evidence_files": [
+                    str(before_path),
+                    str(after_path),
+                    str(config_copy_path),
+                    str(result_path),
+                ],
+                "scratch_removed": False,
+            }
+        finally:
+            if window is not None:
+                window.tray_icon.hide()
+                window.settings_panel.hide()
+                window.hide()
+                window.deleteLater()
+            if app is not None:
+                app.processEvents()
+                app.quit()
+
+    if result_values is None:
+        raise RuntimeError("The settings drive did not produce a result")
+    result_values["scratch_removed"] = not run.working_dir.parent.exists()
+    result = VerificationResult(**result_values)
+    result_path.write_text(
+        json.dumps(asdict(result), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return result
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Drive Bongo Cat's real Qt settings path in isolated state."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("doctor", help="Check Qt and bundled skin discovery.")
+    settings_parser = subparsers.add_parser(
+        "settings-apply",
+        help="Click Apply and preserve rendered and persisted evidence.",
+    )
+    settings_parser.add_argument(
+        "--evidence-dir",
+        type=Path,
+        required=True,
+        help="Absolute directory for PNG, JSON, and config evidence.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+    if args.command == "doctor":
+        return doctor(REPO_ROOT)
+
+    evidence_dir = args.evidence_dir.expanduser()
+    if not evidence_dir.is_absolute():
+        raise SystemExit("--evidence-dir must be absolute")
+
+    with tempfile.TemporaryDirectory(prefix="verify-bongocat-") as scratch:
+        scratch_path = Path(scratch)
+        working_dir = scratch_path / "working"
+        appdata_dir = scratch_path / "appdata"
+        working_dir.mkdir()
+        appdata_dir.mkdir()
+        run = VerificationRun(
+            repo_root=REPO_ROOT,
+            working_dir=working_dir,
+            appdata_dir=appdata_dir,
+            evidence_dir=evidence_dir,
+        )
+        result = drive_settings_apply(run)
+
+    result_path = evidence_dir / "result.json"
+    result_values = asdict(result)
+    result_values["scratch_removed"] = not scratch_path.exists()
+    result = VerificationResult(**result_values)
+    result_path.write_text(
+        json.dumps(asdict(result), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(asdict(result), indent=2, sort_keys=True))
+    return 0 if result.status == "ok" and result.scratch_removed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/README.md
+++ b/README.md
@@ -53,9 +53,11 @@ Hover the cat → ⚙ Settings opens the GUI. Click 📄 to open the ini directl
 
 Config file lives at:
 
-- **Windows**: `%APPDATA%/bongo.ini`
-- **macOS**: `~/Library/Application Support/bongo.ini`
-- **Linux**: `~/.config/bongo.ini`
+- **Windows**: `%APPDATA%\BongoCat\bongo.ini`
+- **macOS**: `~/.config/BongoCat/bongo.ini`
+- **Linux**: `~/.config/BongoCat/bongo.ini`
+
+Direct INI edits load the next time Bongo Cat starts. The app does not reload the file while it is running.
 
 | Key | Effect | Default |
 |-----|--------|---------|

--- a/bongo_cat/__init__.py
+++ b/bongo_cat/__init__.py
@@ -6,7 +6,7 @@ from .input import InputManager
 from .utils import resource_path, setup_logging
 from . import animations
 
-__version__ = "2.0.6"
+__version__ = "2.0.7"
 __author__ = "luinbytes"
 __description__ = "Interactive desktop pet that responds to keyboard, mouse, and controller inputs"
 

--- a/bongo_cat/models/config.py
+++ b/bongo_cat/models/config.py
@@ -2,8 +2,10 @@
 
 import os
 import configparser
+import locale
 import logging
-from typing import Any, Dict
+import tempfile
+from typing import Any, Dict, Tuple
 from ..utils import resource_path
 
 logger = logging.getLogger("BongoCat")
@@ -212,31 +214,85 @@ class ConfigManager:
         except (ValueError, TypeError):
             return default
 
-    def save(self) -> None:
-        """Save current configuration to file."""
+    def _read_latest_config(self) -> Tuple[configparser.ConfigParser, str]:
+        encodings = ("utf-8", locale.getpreferredencoding(False), "cp1252")
+        tried_encodings = set()
+        last_decode_error = None
+
+        for encoding in encodings:
+            normalized_encoding = encoding.lower().replace("_", "-")
+            if normalized_encoding in tried_encodings:
+                continue
+            tried_encodings.add(normalized_encoding)
+
+            latest = configparser.ConfigParser()
+            try:
+                with open(self.config_path, encoding=encoding) as config_file:
+                    latest.read_file(config_file)
+                return latest, encoding
+            except UnicodeDecodeError as error:
+                last_decode_error = error
+
+        if last_decode_error is not None:
+            raise last_decode_error
+        return configparser.ConfigParser(), "utf-8"
+
+    def _write_updates(self, updates: Dict[str, str]) -> None:
+        latest = configparser.ConfigParser()
+        config_encoding = "utf-8"
+        temporary_path = None
         try:
-            self.config["Settings"]["slaps"] = str(self.slaps)
-            self.config["Settings"]["hidden_footer"] = str(self.hidden_footer).lower()
-            self.config["Settings"]["footer_alpha"] = str(self.footer_alpha)
-            self.config["Settings"]["always_show_points"] = str(self.always_show_points).lower()
-            self.config["Settings"]["floating_points"] = str(self.floating_points).lower()
-            self.config["Settings"]["startup_with_windows"] = str(self.startup_with_windows).lower()
-            self.config["Settings"]["max_slaps"] = str(self.max_slaps)
-            self.config["Settings"]["invert_cat"] = str(self.invert_cat).lower()
-            self.config["Settings"]["current_skin"] = self.current_skin
-            self.config["Settings"]["sound_enabled"] = str(self.sound_enabled).lower()
-            self.config["Settings"]["sound_volume"] = str(self.sound_volume)
-            self.config["Settings"]["window_x"] = str(self.window_x)
-            self.config["Settings"]["window_y"] = str(self.window_y)
-            self.config["Settings"]["launch_count"] = str(self.launch_count)
+            if os.path.exists(self.config_path):
+                latest, config_encoding = self._read_latest_config()
 
-            with open(self.config_path, "w") as config_file:
-                self.config.write(config_file)
+            for section, values in self.DEFAULT_CONFIG.items():
+                if section not in latest:
+                    latest[section] = {}
+                for key, value in values.items():
+                    if key not in latest[section]:
+                        latest[section][key] = value
 
-            logger.debug("Configuration saved successfully")
+            for key, value in updates.items():
+                latest["Settings"][key] = value
 
-        except (IOError, OSError) as e:
-            logger.error(f"Error saving config to {self.config_path}: {e}")
+            config_dir = os.path.dirname(os.path.abspath(self.config_path))
+            with tempfile.NamedTemporaryFile(
+                "w",
+                encoding=config_encoding,
+                dir=config_dir,
+                prefix=".bongo-",
+                suffix=".ini.tmp",
+                delete=False,
+            ) as temporary_file:
+                temporary_path = temporary_file.name
+                latest.write(temporary_file)
+
+            os.replace(temporary_path, self.config_path)
+            temporary_path = None
+            self.config = latest
+        except (IOError, OSError, UnicodeError, configparser.Error, TypeError) as error:
+            logger.error(f"Error updating config at {self.config_path}: {error}")
+        finally:
+            if temporary_path is not None:
+                try:
+                    os.remove(temporary_path)
+                except OSError:
+                    logger.warning(f"Could not remove temporary config: {temporary_path}")
+
+    def save_user_settings(self) -> None:
+        """Persist only the settings controlled by the Settings window."""
+        self._write_updates({
+            "hidden_footer": str(self.hidden_footer).lower(),
+            "footer_alpha": str(self.footer_alpha),
+            "always_show_points": str(self.always_show_points).lower(),
+            "floating_points": str(self.floating_points).lower(),
+            "startup_with_windows": str(self.startup_with_windows).lower(),
+            "max_slaps": str(self.max_slaps),
+            "invert_cat": str(self.invert_cat).lower(),
+            "current_skin": self.current_skin,
+            "sound_enabled": str(self.sound_enabled).lower(),
+            "sound_volume": str(self.sound_volume),
+        })
 
     def update_slap_count(self, count: int) -> None:
         """Efficiently update only the slap count.
@@ -248,14 +304,18 @@ class ConfigManager:
             count: New slap count value
         """
         self.slaps = count
-        try:
-            self.config["Settings"]["slaps"] = str(count)
+        self._write_updates({"slaps": str(count)})
 
-            with open(self.config_path, "w") as config_file:
-                self.config.write(config_file)
+    def update_window_position(self, x: int, y: int) -> None:
+        """Persist only the current window position."""
+        self.window_x = x
+        self.window_y = y
+        self._write_updates({"window_x": str(x), "window_y": str(y)})
 
-        except (IOError, OSError) as e:
-            logger.error(f"Error updating slap count in {self.config_path}: {e}")
+    def increment_launch_count(self) -> None:
+        """Increment and persist only the launch count."""
+        self.launch_count += 1
+        self._write_updates({"launch_count": str(self.launch_count)})
 
     def get(self, key: str, default: Any = None) -> Any:
         """Get a configuration value by attribute name.

--- a/bongo_cat/models/skin_manager.py
+++ b/bongo_cat/models/skin_manager.py
@@ -6,6 +6,8 @@ import logging
 from typing import Dict, List, Optional
 from dataclasses import dataclass
 
+from ..utils import resource_path
+
 logger = logging.getLogger("BongoCat")
 
 
@@ -47,13 +49,13 @@ class SkinManager:
         current_skin: Currently loaded skin
     """
 
-    def __init__(self, skins_dir: str = "skins"):
+    def __init__(self, skins_dir: Optional[str] = None):
         """Initialize the skin manager.
 
         Args:
             skins_dir: Path to the skins directory
         """
-        self.skins_dir = skins_dir
+        self.skins_dir = resource_path("skins") if skins_dir is None else skins_dir
         self.available_skins: Dict[str, SkinInfo] = {}
         self.current_skin: Optional[SkinInfo] = None
         self._discover_skins()

--- a/bongo_cat/ui/main_window.py
+++ b/bongo_cat/ui/main_window.py
@@ -83,8 +83,7 @@ class BongoCatWindow(QtWidgets.QWidget):
             self.show_total_slaps()
 
         # Increment launch count and check achievements
-        self.config.launch_count += 1
-        self.config.save()
+        self.config.increment_launch_count()
 
         # Check for time-based achievements
         time_achievements = self.achievement_manager.check_time_based()
@@ -787,9 +786,7 @@ class BongoCatWindow(QtWidgets.QWidget):
             # Save window position if it was dragged
             if self.drag_position:
                 pos = self.pos()
-                self.config.window_x = pos.x()
-                self.config.window_y = pos.y()
-                self.config.save()
+                self.config.update_window_position(pos.x(), pos.y())
 
             if not self._footer_effect_alive():
                 self.original_opacity = 1.0
@@ -946,10 +943,7 @@ class BongoCatWindow(QtWidgets.QWidget):
             x = (geometry.width() - self.width()) // 2
             y = (geometry.height() - self.height()) // 2
             self.move(x, y)
-            # Save this initial position
-            self.config.window_x = x
-            self.config.window_y = y
-            self.config.save()
+            self.config.update_window_position(x, y)
 
     # ----------------------
     #  Configuration
@@ -1317,12 +1311,12 @@ class BongoCatWindow(QtWidgets.QWidget):
 
         # Save every selection before refreshing runtime objects. If a Qt or
         # audio object fails, a restart can still load the requested settings.
-        selected_skin_id = self.config.skin_dropdown.currentData()
+        selected_skin_id = self._selected_skin_id()
         skin_changed = selected_skin_id != self.config.current_skin
         self.config.current_skin = selected_skin_id
         self.config.sound_enabled = self.config.sound_enabled_checkbox.isChecked()
         self.config.sound_volume = self.config.sound_volume_slider.value()
-        self.config.save()
+        self.config.save_user_settings()
 
         # Update skin
         if skin_changed:
@@ -1367,6 +1361,17 @@ class BongoCatWindow(QtWidgets.QWidget):
         if old_invert_cat != self.config.invert_cat:
             self.update_stretched_image()
 
+    def _selected_skin_id(self) -> str:
+        selected_skin_id = self.config.skin_dropdown.currentData()
+        if (
+            isinstance(selected_skin_id, str)
+            and selected_skin_id in self.skin_manager.available_skins
+        ):
+            return selected_skin_id
+
+        logger.warning("No valid skin is selected; keeping the current skin")
+        return self.config.current_skin
+
     def apply_settings_safely(self):
         """Keep exceptions in the Qt Apply callback from aborting the app."""
         try:
@@ -1402,6 +1407,7 @@ class BongoCatWindow(QtWidgets.QWidget):
         """Set up the settings panel as a separate window."""
         # Create settings panel as a top-level window
         self.settings_panel = SettingsPanelWidget(self)
+        self.settings_panel.setObjectName("settingsPanel")
         self.settings_panel.setWindowTitle("Bongo Cat Settings")
         
         # Set window flags for a dialog-like appearance
@@ -1508,6 +1514,7 @@ class BongoCatWindow(QtWidgets.QWidget):
 
         # Skin selection
         self.config.skin_dropdown = QtWidgets.QComboBox()
+        self.config.skin_dropdown.setObjectName("skinDropdown")
         self.config.skin_dropdown.setStyleSheet("""
             color: white;
             background-color: rgba(255, 255, 255, 0.1);
@@ -1522,10 +1529,12 @@ class BongoCatWindow(QtWidgets.QWidget):
         current_index = self.config.skin_dropdown.findData(self.config.current_skin)
         if current_index >= 0:
             self.config.skin_dropdown.setCurrentIndex(current_index)
+        self.config.skin_dropdown.setEnabled(self.config.skin_dropdown.count() > 0)
         form_layout.addRow(self.create_settings_label("Cat Skin:"), self.config.skin_dropdown)
 
         # Sound enabled toggle
         self.config.sound_enabled_checkbox = QtWidgets.QCheckBox()
+        self.config.sound_enabled_checkbox.setObjectName("soundEnabledCheckbox")
         self.config.sound_enabled_checkbox.setChecked(self.config.sound_enabled)
         self.config.sound_enabled_checkbox.setStyleSheet("color: white;")
         form_layout.addRow(self.create_settings_label("Enable Sounds:"), self.config.sound_enabled_checkbox)
@@ -1565,6 +1574,7 @@ class BongoCatWindow(QtWidgets.QWidget):
         
         # Apply button
         apply_button = QtWidgets.QPushButton("Apply")
+        apply_button.setObjectName("applySettingsButton")
         apply_button.setStyleSheet("""
             background-color: #2ecc71;
             color: white;

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,6 +8,8 @@ import configparser
 # Add parent directory to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from bongo_cat.models.config import ConfigManager
+
 
 class TestConfigDefaults(unittest.TestCase):
     """Test configuration default values."""
@@ -168,6 +170,87 @@ class TestConfigFileOperations(unittest.TestCase):
 
         self.assertEqual(new_config.get("Settings", "slaps"), "100")
         self.assertEqual(new_config.get("Settings", "hidden_footer"), "true")
+
+    def _edit_config(self, **updates):
+        config = configparser.ConfigParser()
+        config.read(self.config_path)
+        for key, value in updates.items():
+            config["Settings"][key] = value
+        with open(self.config_path, "w") as config_file:
+            config.write(config_file)
+
+    def _read_settings(self):
+        config = configparser.ConfigParser()
+        config.read(self.config_path)
+        return config["Settings"]
+
+    def test_slap_count_update_preserves_completed_external_edit(self):
+        manager = ConfigManager(self.config_path)
+        self._edit_config(sound_enabled="false", current_skin="retro")
+
+        manager.update_slap_count(41)
+
+        settings = self._read_settings()
+        restarted = ConfigManager(self.config_path)
+        self.assertEqual("41", settings["slaps"])
+        self.assertEqual("false", settings["sound_enabled"])
+        self.assertEqual("retro", settings["current_skin"])
+        self.assertEqual(41, restarted.slaps)
+        self.assertFalse(restarted.sound_enabled)
+        self.assertEqual("retro", restarted.current_skin)
+
+    def test_window_position_update_preserves_other_external_values(self):
+        manager = ConfigManager(self.config_path)
+        self._edit_config(sound_enabled="false", current_skin="retro", slaps="12")
+
+        manager.update_window_position(120, 240)
+
+        settings = self._read_settings()
+        self.assertEqual("120", settings["window_x"])
+        self.assertEqual("240", settings["window_y"])
+        self.assertEqual("12", settings["slaps"])
+        self.assertEqual("false", settings["sound_enabled"])
+        self.assertEqual("retro", settings["current_skin"])
+
+    def test_launch_count_update_preserves_other_external_values(self):
+        manager = ConfigManager(self.config_path)
+        self._edit_config(sound_enabled="false", current_skin="retro", slaps="12")
+
+        manager.increment_launch_count()
+
+        settings = self._read_settings()
+        self.assertEqual("1", settings["launch_count"])
+        self.assertEqual("12", settings["slaps"])
+        self.assertEqual("false", settings["sound_enabled"])
+        self.assertEqual("retro", settings["current_skin"])
+
+    def test_scoped_update_leaves_malformed_config_untouched(self):
+        manager = ConfigManager(self.config_path)
+        malformed = "[Settings\nsound_enabled = false\n"
+        with open(self.config_path, "w") as config_file:
+            config_file.write(malformed)
+
+        manager.update_slap_count(9)
+
+        with open(self.config_path, encoding="utf-8") as config_file:
+            self.assertEqual(malformed, config_file.read())
+        self.assertEqual(9, manager.slaps)
+
+    def test_scoped_update_preserves_legacy_windows_encoding(self):
+        manager = ConfigManager(self.config_path)
+        legacy_config = "[Settings]\ncurrent_skin = caf\N{LATIN SMALL LETTER E WITH ACUTE}\n"
+        with open(self.config_path, "w", encoding="cp1252") as config_file:
+            config_file.write(legacy_config)
+
+        manager.update_slap_count(2)
+
+        config = configparser.ConfigParser()
+        with open(self.config_path, encoding="cp1252") as config_file:
+            config.read_file(config_file)
+        self.assertEqual("2", config["Settings"]["slaps"])
+        self.assertEqual("caf\N{LATIN SMALL LETTER E WITH ACUTE}", config["Settings"]["current_skin"])
+        with open(self.config_path, "rb") as config_file:
+            self.assertIn(b"caf\xe9", config_file.read())
 
 
 if __name__ == '__main__':

--- a/tests/test_settings_apply_runtime.py
+++ b/tests/test_settings_apply_runtime.py
@@ -12,6 +12,69 @@ import unittest
 
 @unittest.skipUnless(importlib.util.find_spec("PyQt5"), "PyQt5 is not installed")
 class TestSettingsApplyRuntime(unittest.TestCase):
+    def test_apply_from_unrelated_cwd_discovers_skins_and_persists_settings(self):
+        script = textwrap.dedent(
+            """
+            from PyQt5 import QtCore, QtTest, QtWidgets
+            from bongo_cat.ui.main_window import BongoCatWindow
+
+            app = QtWidgets.QApplication([])
+            window = BongoCatWindow()
+            window.open_settings_dialog()
+            app.processEvents()
+            apply_button = next(
+                button
+                for button in window.settings_panel.findChildren(QtWidgets.QPushButton)
+                if button.text() == "Apply"
+            )
+            errors = []
+            QtWidgets.QMessageBox.critical = lambda *_args: errors.append("apply-error")
+            selected_skin = window.config.skin_dropdown.currentData()
+            print(f"skin-options={window.config.skin_dropdown.count()}", flush=True)
+            print(f"selected-skin={selected_skin}", flush=True)
+            print(f"selected-skin-type={type(selected_skin).__name__}", flush=True)
+            window.config.sound_enabled_checkbox.setChecked(False)
+            QtTest.QTest.mouseClick(apply_button, QtCore.Qt.LeftButton)
+            app.processEvents()
+            reloaded = window.config.__class__()
+            print(f"apply-errors={len(errors)}", flush=True)
+            print(f"saved-sound-enabled={reloaded.sound_enabled}", flush=True)
+            window.tray_icon.hide()
+            window.settings_panel.hide()
+            window.hide()
+            app.quit()
+            """
+        )
+
+        repo_root = Path(__file__).parents[1].resolve()
+        with tempfile.TemporaryDirectory() as appdata:
+            with tempfile.TemporaryDirectory() as unrelated_cwd:
+                env = os.environ.copy()
+                python_path = env.get("PYTHONPATH")
+                env.update(
+                    APPDATA=appdata,
+                    PYNPUT_BACKEND="dummy",
+                    PYTHONPATH=os.pathsep.join(
+                        path for path in (str(repo_root), python_path) if path
+                    ),
+                    QT_QPA_PLATFORM="offscreen",
+                )
+                result = subprocess.run(
+                    [sys.executable, "-c", script],
+                    cwd=unrelated_cwd,
+                    env=env,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("skin-options=3", result.stdout)
+        self.assertIn("selected-skin=default", result.stdout)
+        self.assertIn("selected-skin-type=str", result.stdout)
+        self.assertIn("apply-errors=0", result.stdout)
+        self.assertIn("saved-sound-enabled=False", result.stdout)
+
     def test_apply_exception_does_not_abort_qt_process(self):
         script = textwrap.dedent(
             """

--- a/tests/test_skin_manager.py
+++ b/tests/test_skin_manager.py
@@ -1,0 +1,44 @@
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+
+from bongo_cat.models.skin_manager import SkinManager
+
+
+class TestSkinManagerPaths(unittest.TestCase):
+    def test_explicit_relative_skin_directory_stays_authoritative(self):
+        with tempfile.TemporaryDirectory() as working_dir:
+            skin_root = Path(working_dir, "custom-skins")
+            skin_dir = skin_root / "fixture"
+            skin_dir.mkdir(parents=True)
+            (skin_dir / "skin.json").write_text(
+                json.dumps(
+                    {
+                        "name": "Fixture",
+                        "images": {
+                            "idle": "cat-rest.png",
+                            "left": "cat-left.png",
+                            "right": "cat-right.png",
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            for image_name in ("cat-rest.png", "cat-left.png", "cat-right.png"):
+                (skin_dir / image_name).write_bytes(b"fixture")
+
+            original_cwd = os.getcwd()
+            try:
+                os.chdir(working_dir)
+                manager = SkinManager("custom-skins")
+            finally:
+                os.chdir(original_cwd)
+
+        self.assertEqual("custom-skins", manager.skins_dir)
+        self.assertEqual(["fixture"], manager.get_skin_ids())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

Bongo Cat v2.0.6 can still fail when a packaged Windows build starts outside its resource directory. The skin selector then has no items, and Settings passes `None` to `ConfigParser`.

Runtime counter, window-position, and launch-count writes also serialize stale in-memory settings. Those writes can replace a direct INI edit that the user already completed.

## Scope

- Resolve the default `SkinManager` directory through `resource_path("skins")` while preserving explicit custom paths.
- Require a known string skin ID at the Qt boundary before Settings saves it.
- Replace the broad config writer with scoped updates that reread the latest valid INI and atomically replace it.
- Preserve UTF-8, system-locale, and legacy Windows CP1252 files. Leave malformed files untouched.
- Add real Apply-button regression coverage and a project-local Bongo Cat verification skill.
- Document the real config paths and the restart requirement for direct INI edits.
- Set the package version to `2.0.7`.

## Tradeoffs

Direct INI edits do not change live values. Restart Bongo Cat to load them. Runtime writes now preserve keys they do not own.

## Blast Radius

The change affects bundled skin discovery and configuration persistence. Explicit skin-directory injection remains unchanged. The Settings error boundary from v2.0.6 remains in place.

Issue #10 stays open for reporter validation of the published Windows artifact.

Refs #10.

## Verification

- `python -m unittest discover tests -v` passed 30 tests with 2 expected platform skips.
- `control.py doctor` found `default`, `neon`, and `retro` from the application resource path.
- `control.py settings-apply` clicked the production Apply button from an unrelated working directory. It recorded no error dialog and read back `sound_enabled = false` from a new `ConfigManager`.
- The CP1252 regression test failed before the fallback and passed after it.
- Python 3.8 syntax parsing passed for all changed Python files.
- `git diff --check` passed.
