### PR TITLE
fix(ci): run headless input tests without X

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,7 @@ jobs:
 
       - name: Run tests
         env:
+          PYNPUT_BACKEND: dummy
           QT_QPA_PLATFORM: offscreen
         run: python -m unittest discover tests -v
 

--- a/bongo_cat/__init__.py
+++ b/bongo_cat/__init__.py
@@ -6,7 +6,7 @@ from .input import InputManager
 from .utils import resource_path, setup_logging
 from . import animations
 
-__version__ = "2.0.7"
+__version__ = "2.0.8"
 __author__ = "luinbytes"
 __description__ = "Interactive desktop pet that responds to keyboard, mouse, and controller inputs"
 


### PR DESCRIPTION
## Why

The `v2.0.7` release run stopped before publication because the Linux test process imported `pynput` without an X display. macOS and Windows completed, but the release job correctly stayed skipped after the Linux failure.

## Scope

- Set `PYNPUT_BACKEND=dummy` only for the release workflow's test step.
- Keep every platform's PyInstaller build on its native input backend.
- Set the package version to `2.0.8` for the next immutable release tag.

The failed `v2.0.7` tag remains unchanged and has no GitHub Release.

## Blast Radius

The workflow change affects only test discovery in release CI. It does not change packaged input handling or application behavior.

## Verification

- The `v2.0.7` Linux log failed at `pynput` with `failed to acquire X connection`.
- `PYNPUT_BACKEND=dummy QT_QPA_PLATFORM=offscreen python -m unittest discover tests -v` passed 30 tests with 2 expected platform skips.
- `actionlint .github/workflows/release.yml` passed.
- YAML read-back confirmed both headless test variables.
- Package-version read-back returned `2.0.8`.
- `git diff --check` passed.
